### PR TITLE
Conditionally execute docker build with --squash option

### DIFF
--- a/base-dockerfiles/base/build.sh
+++ b/base-dockerfiles/base/build.sh
@@ -31,5 +31,11 @@ repository=${product}-${platform}-${profile}
 tag=${productVersion}
 
 echo "Creating ${repository}:${tag}..."
-docker build -t ${repository}:${tag} . --squash
+docker_api_version=`docker version | grep -m2 "API version" | tail -n1 | cut -d' ' -f5 | bc -l`
+echo "Docker API version: ${docker_api_version}"
+if (( $(echo $docker_api_version '>=' 1.25 | bc -l) )); then
+    docker build -t ${repository}:${tag} . --squash
+else
+    docker build -t ${repository}:${tag} .
+fi
 docker images --filter "dangling=true" -q --no-trunc | xargs docker rmi

--- a/pattern-1/dockerfiles/integrator/build.sh
+++ b/pattern-1/dockerfiles/integrator/build.sh
@@ -32,5 +32,11 @@ repository=${product}-${platform}-pattern${patternNumber}-${profile}
 tag=${productVersion}
 
 echo "Creating ${repository}:${tag}..."
-docker build -t ${repository}:${tag} . --squash
+docker_api_version=`docker version | grep -m2 "API version" | tail -n1 | cut -d' ' -f5 | bc -l`
+echo "Docker API version: ${docker_api_version}"
+if (( $(echo $docker_api_version '>=' 1.25 | bc -l) )); then
+    docker build -t ${repository}:${tag} . --squash
+else
+    docker build -t ${repository}:${tag} .
+fi
 docker images --filter "dangling=true" -q --no-trunc | xargs docker rmi


### PR DESCRIPTION
Docker build squash option has been introduced in Docker API version 1.25. Therefore the current docker build command fails on Docker environments where Docker API version is less than 1.25. This pull request has updated the docker build command to conditionally use --squash option if Docker API version is >= 1.25.