### PR TITLE
Add Ingress Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # WSO2 Enterprise Integrator Kubernetes Artifacts 
-*Kubernetes Artifacts for Container-based Deployment Patterns
-of WSO2 Enterprise Integrator*
+*Kubernetes Artifacts for container-based deployments of WSO2 Enterprise Integrator*
 
 
 This initial version contains the deployment of a single integrator container instance 
@@ -17,7 +16,7 @@ Kubernetes client, kubectl installed in your local machine to execute following 
 git clone https://github.com/wso2/kubernetes-ei.git
 ```
 
-##### 2. Pull required Docker images from [`WSO2 Docker Repositories`](https://docker.wso2.com) using `docker pull`:
+##### 2. Pull required Docker images from [`WSO2 Docker Registry`](https://docker.wso2.com) using `docker pull`:
 ```
 docker pull docker.wso2.com/wso2ei-kubernetes-pattern1-integrator:6.1.1
 docker pull docker.wso2.com/wso2ei-kubernetes-pattern1-mysql:5.5

--- a/pattern-1/dockerfiles/integrator/files/conf/carbon.xml
+++ b/pattern-1/dockerfiles/integrator/files/conf/carbon.xml
@@ -44,12 +44,12 @@
        This is will become part of the End Point Reference of the
        services deployed on this server instance.
     -->
-    <HostName>wso2ei-pattern1-integrator-service</HostName>
+    <HostName>wso2ei-pattern1-integrator-gateway</HostName>
 
     <!--
     Host name to be used for the Carbon management console
     -->
-    <MgtHostName>wso2ei-pattern1-integrator-service</MgtHostName>
+    <MgtHostName>wso2ei-pattern1-integrator</MgtHostName>
 
     <!--
         The URL of the back end server. This is where the admin services are hosted and

--- a/pattern-1/integrator-gateway-service.yaml
+++ b/pattern-1/integrator-gateway-service.yaml
@@ -15,17 +15,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2ei-pattern1-integrator-service
+  name: wso2ei-pattern1-integrator-gateway-service
 spec:
-  sessionAffinity: ClientIP
   selector:
     deployment: wso2ei-pattern1-integrator
   ports:
-  - name: servlet-http
-    port: 9763
-    targetPort: 9763
+  - name: pass-through-http
+    port: 8280
+    targetPort: 8280
     protocol: TCP
-  - name: servlet-https
-    port: 9443
-    targetPort: 9443
+  - name: pass-through-https
+    port: 8243
+    targetPort: 8243
     protocol: TCP

--- a/pattern-1/integrator-ingress.yaml
+++ b/pattern-1/integrator-ingress.yaml
@@ -12,20 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
+apiVersion: extensions/v1beta1
+kind: Ingress
 metadata:
   name: wso2ei-pattern1-integrator-service
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
-  sessionAffinity: ClientIP
-  selector:
-    deployment: wso2ei-pattern1-integrator
-  ports:
-  - name: servlet-http
-    port: 9763
-    targetPort: 9763
-    protocol: TCP
-  - name: servlet-https
-    port: 9443
-    targetPort: 9443
-    protocol: TCP
+  tls:
+  - hosts:
+    - wso2ei-pattern1-integrator
+    - wso2ei-pattern1-integrator-gateway
+  rules:
+  - host: wso2ei-pattern1-integrator
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: wso2ei-pattern1-integrator-service
+          servicePort: 9443
+  - host: wso2ei-pattern1-integrator-gateway
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: wso2ei-pattern1-integrator-gateway-service
+          servicePort: 8243

--- a/pattern-1/nginx-default-backend.yaml
+++ b/pattern-1/nginx-default-backend.yaml
@@ -1,0 +1,68 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source reference: 
+# https://github.com/kubernetes/ingress/tree/nginx-0.9.0-beta.11/
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-default-http-backend
+  labels:
+    k8s-app: nginx-default-http-backend
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: nginx-default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-default-http-backend
+  namespace: kube-system
+  labels:
+    k8s-app: nginx-default-http-backend
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    k8s-app: nginx-default-http-backend

--- a/pattern-1/nginx-ingress-controller.yaml
+++ b/pattern-1/nginx-ingress-controller.yaml
@@ -1,0 +1,69 @@
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Source reference: 
+# https://github.com/kubernetes/ingress/tree/nginx-0.9.0-beta.11/
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  labels:
+    k8s-app: nginx-ingress-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: nginx-ingress-controller
+    spec:
+      # hostNetwork makes it possible to use ipv6 and to preserve the source IP correctly regardless of docker configuration
+      # however, it is not a hard dependency of the nginx-ingress-controller itself and it may cause issues if port 10254 already is taken on the host
+      # that said, since hostPort is broken on CNI (https://github.com/kubernetes/kubernetes/issues/31307) we have to use hostNetwork where CNI is used
+      # like with kubeadm
+      # hostNetwork: true
+      terminationGracePeriodSeconds: 60
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
+        name: nginx-ingress-controller
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        ports:
+        - containerPort: 80
+          hostPort: 80
+        - containerPort: 443
+          hostPort: 443
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=$(POD_NAMESPACE)/nginx-default-http-backend


### PR DESCRIPTION
This pull request has following improvements:
- Added integrator ingress definition
- Added nginx ingress controller
- Added nginx default endpoint
- Split integrator service into two services for defining session affinity for servlet transport (management console)
- Removed node ports in services
- Updated root README.md file