### PR TITLE
Add support for pulling WSO2 Enterprise Integrator Docker images from WSO2 Private Docker Registry

### DIFF
--- a/integrator/README.md
+++ b/integrator/README.md
@@ -6,6 +6,10 @@ Core Kubernetes resources for deployment of a "scalable" unit of WSO2 Enterprise
 
 ## Prerequisites
 
+* In order to use these Kubernetes resources, you will need an active [Free Trial Subscription](https://wso2.com/free-trial-subscription)
+from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 Enterprise Integrator.
+You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription).<br><br>
+
 * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker)
 (version 17.09.0 or above) and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 in order to run the steps provided<br>in the following quick start guide.<br><br>
@@ -23,7 +27,20 @@ Git repository.<br>
 git clone https://github.com/wso2/kubernetes-ei.git
 ```
 
-##### 2. Build the Docker images using the [`Docker resources`](../dockerfiles) provided in this repository.
+##### 2. Create a Kubernetes Secret for pulling the required Docker images from [`WSO2 Docker Registry`](https://docker.wso2.com):
+
+Create a Kubernetes Secret named `wso2creds` in the cluster to authenticate with the WSO2 Docker Registry, to pull the required images.
+
+```a
+kubectl create secret docker-registry wso2creds --docker-server=docker.wso2.com --docker-username=<username> --docker-password=<password> --docker-email=<email>
+```
+
+`username`: Username of your Free Trial Subscription<br>
+`password`: Password of your Free Trial Subscription<br>
+`email`: Docker email
+
+Please see [Kubernetes official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-in-the-cluster-that-holds-your-authorization-token)
+for further details.
 
 ##### 3. Copy the Docker images into the Kubernetes Nodes or Registry:
 

--- a/integrator/README.md
+++ b/integrator/README.md
@@ -31,7 +31,7 @@ git clone https://github.com/wso2/kubernetes-ei.git
 
 Create a Kubernetes Secret named `wso2creds` in the cluster to authenticate with the WSO2 Docker Registry, to pull the required images.
 
-```a
+```
 kubectl create secret docker-registry wso2creds --docker-server=docker.wso2.com --docker-username=<username> --docker-password=<password> --docker-email=<email>
 ```
 
@@ -42,15 +42,7 @@ kubectl create secret docker-registry wso2creds --docker-server=docker.wso2.com 
 Please see [Kubernetes official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-in-the-cluster-that-holds-your-authorization-token)
 for further details.
 
-##### 3. Copy the Docker images into the Kubernetes Nodes or Registry:
-
-Copy the required Docker images over to the Kubernetes Nodes (e.g. use `docker save` to create a tarfile of the 
-required image, `scp` the tarfile to each node and use `docker load` to load the image from the copied tarfile 
-within the nodes).
-
-Alternatively, if a private Docker registry is used, transfer the images there.
-
-##### 4. Setup and configure external product database(s):
+##### 3. Setup and configure external product database(s):
 
 Setup the external product databases. Please refer to WSO2 Enterprise Integrator's [official documentation](https://docs.wso2.com/display/EI620/Clustering+the+ESB+Profile#ClusteringtheESBProfile-Creatingthedatabases)
 on creating the required databases for the deployment.
@@ -81,7 +73,7 @@ Provide appropriate connection URLs, corresponding to the created external datab
     kubectl create -f <KUBERNETES_HOME>/integrator/test/rdbms/mysql/mysql-deployment.yaml
     ```
     
-##### 5. Create Kubernetes ConfigMaps for passing WSO2 product configurations into the Kubernetes cluster:
+##### 4. Create Kubernetes ConfigMaps for passing WSO2 product configurations into the Kubernetes cluster:
 
 ```
 kubectl create configmap integrator-conf --from-file=<KUBERNETES_HOME>/integrator/conf/integrator/conf/
@@ -89,7 +81,7 @@ kubectl create configmap integrator-conf-axis2 --from-file=<KUBERNETES_HOME>/int
 kubectl create configmap integrator-conf-datasources --from-file=<KUBERNETES_HOME>/integrator/conf/integrator/conf/datasources/
 ```
 
-##### 6. Create Kubernetes Services and Deployments for WSO2 Enterprise Integrator:
+##### 5. Create Kubernetes Services and Deployments for WSO2 Enterprise Integrator:
 
 ```
 kubectl create -f <KUBERNETES_HOME>/integrator/integrator/integrator-service.yaml
@@ -97,7 +89,7 @@ kubectl create -f <KUBERNETES_HOME>/integrator/integrator/integrator-gateway-ser
 kubectl create -f <KUBERNETES_HOME>/integrator/integrator/integrator-deployment.yaml
 ```
 
-##### 7. Deploy Kubernetes Ingress resource:
+##### 6. Deploy Kubernetes Ingress resource:
 
 The ingress resource uses NGINX Ingress Controller. Hence, the user should enable NGINX Ingress controller
 in the particular environment.
@@ -116,7 +108,7 @@ Finally, deploy the Kubernetes Ingress resource as follows:
 kubectl create -f <KUBERNETES_HOME>/integrator/ingresses/integrator-ingress.yaml
 ```
 
-##### 8. Access Management Console:
+##### 7. Access Management Console:
 
 Default deployment will expose two publicly accessible hosts, namely: <br>
 1. `wso2ei-pattern1-integrator` - To expose Administrative services and Management Console <br>
@@ -125,7 +117,7 @@ Default deployment will expose two publicly accessible hosts, namely: <br>
 To access the console in a test environment, add the above two hosts as entries in /etc/hosts file, pointing to one of<br>
 your Kubernetes cluster node IPs and try navigating to `https://wso2ei-pattern1-integrator/carbon` from your favorite browser.
 
-##### 9. How to scale using `kubectl scale`:
+##### 8. How to scale using `kubectl scale`:
 
 Default deployment runs only one replica (or pod) of Integrator profile. To scale this deployment into <br>
 any `<n>` number of container replicas, necessary to suite your requirement, simply run following kubectl 

--- a/integrator/integrator/integrator-deployment.yaml
+++ b/integrator/integrator/integrator-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: wso2ei-pattern1-integrator
-        image: wso2ei-integrator:6.2.0
+        image: docker.wso2.com/wso2ei-integrator:6.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8280
@@ -43,6 +43,8 @@ spec:
           mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf-axis2
         - name: integrator-conf-datasources
           mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf-datasources
+      imagePullSecrets:
+      - name: wso2creds
       volumes:
       - name: integrator-conf
         configMap:

--- a/integrator/test/README.md
+++ b/integrator/test/README.md
@@ -5,6 +5,10 @@ Kubernetes resources provided for deployment of a "scalable" unit of WSO2 Enterp
 
 ## Prerequisites
 
+* In order to use these Kubernetes resources, you will need an active [Free Trial Subscription](https://wso2.com/free-trial-subscription)
+from WSO2 since the referring Docker images hosted at docker.wso2.com contains the latest updates and fixes for WSO2 Enterprise Integrator.
+You can sign up for a Free Trial Subscription [here](https://wso2.com/free-trial-subscription).<br><br>
+
 * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker)
 (version 17.09.0 or above) and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 in order to run the steps provided<br>in the following quick start guide.<br><br>
@@ -22,17 +26,22 @@ Git repository.<br>
 git clone https://github.com/wso2/kubernetes-ei.git
 ```
 
-##### 2. Build the Docker images using the [`Docker resources`](../../dockerfiles) provided in this repository.
+##### 2. Create a Kubernetes Secret for pulling the required Docker images from [`WSO2 Docker Registry`](https://docker.wso2.com):
 
-##### 3. Copy the Docker images into the Kubernetes Nodes or Registry:
+Create a Kubernetes Secret named `wso2creds` in the cluster to authenticate with the WSO2 Docker Registry, to pull the required images.
 
-Copy the required Docker images over to the Kubernetes Nodes (e.g. use `docker save` to create a tarfile of the 
-required image, `scp` the tarfile to each node and use `docker load` to load the image from the copied tarfile 
-within the nodes).
+```
+kubectl create secret docker-registry wso2creds --docker-server=docker.wso2.com --docker-username=<username> --docker-password=<password> --docker-email=<email>
+```
 
-Alternatively, if a private Docker registry is used, transfer the images there.
+`username`: Username of your Free Trial Subscription<br>
+`password`: Password of your Free Trial Subscription<br>
+`email`: Docker email
 
-##### 4. Deploy Kubernetes test resources:
+Please see [Kubernetes official documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-in-the-cluster-that-holds-your-authorization-token)
+for further details.
+
+##### 3. Deploy Kubernetes test resources:
 
 Change directory to `KUBERNETES_HOME/integrator/test` and execute the `deploy.sh` shell script on the terminal.
 
@@ -41,7 +50,7 @@ Change directory to `KUBERNETES_HOME/integrator/test` and execute the `deploy.sh
 ```
 >To un-deploy, be on the same directory and execute the `undeploy.sh` shell script on the terminal.
 
-##### 5. Access Management Console:
+##### 4. Access Management Console:
 
 Default deployment will expose two publicly accessible hosts, namely: <br>
 1. `wso2ei-pattern1-integrator` - To expose Administrative services and Management Console <br>


### PR DESCRIPTION
## Purpose
> Add support for pulling WSO2 Enterprise Integrator Docker images from WSO2 Private Docker Registry. This closes https://github.com/wso2/kubernetes-ei/issues/37.

## Goals
> Add support for pulling WSO2 Enterprise Integrator Docker images from WSO2 Private Docker Registry.

## Approach
> Please see official Kubernetes [documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) on this.