### PR TITLE
Introduce health checks and rolling update policy for product instances

### DIFF
--- a/scalable-integrator/integrator-deployment.yaml
+++ b/scalable-integrator/integrator-deployment.yaml
@@ -18,6 +18,12 @@ metadata:
   name: wso2ei-pattern1-integrator-deployment
 spec:
   replicas: 2
+  minReadySeconds: 30
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -26,7 +32,23 @@ spec:
       containers:
       - name: wso2ei-pattern1-integrator
         image: docker.wso2.com/wso2ei-integrator:6.2.0
-        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - nc -z localhost 9443
+          initialDelaySeconds: 100
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+              - /bin/bash
+              - -c
+              - nc -z localhost 9443
+          initialDelaySeconds: 100
+          periodSeconds: 10
+        imagePullPolicy: Always
         ports:
         - containerPort: 8280
           protocol: TCP


### PR DESCRIPTION
## Purpose
> This PR introduces health checks of product instances and defines rolling update policy of the deployment, as well. This closes https://github.com/wso2/kubernetes-ei/issues/67 and closes https://github.com/wso2/kubernetes-ei/issues/68.

## Goals
> Introduces health checks of product instances and defines rolling update policy of the deployment.

## Approach
> This introduces health checks of the product instances. Plus, it defines the `imagePullPolicy` as `Always` in order to facilitate pulling the Docker image with latest WUM updates. And a rolling update policy has been introduced.