### PR TITLE
[6.4.x] Fix incorrect mount path and images 

### DIFF
--- a/scalable-bps/bps-deployment.yaml
+++ b/scalable-bps/bps-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: wso2ei-scalable-bps
-        image: docker.wso2.com/wso2ei-business-process:6.2.0
+        image: docker.wso2.com/wso2ei-business-process:6.4.0
         livenessProbe:
           exec:
             command:
@@ -64,7 +64,7 @@ spec:
         - name: bps-conf-etc
           mountPath: /home/wso2carbon/kubernetes-volumes/business-process/conf/etc
         - name: bps-server-share-volume
-          mountPath: /home/wso2carbon/wso2ei-6.2.0/wso2/business-process/repository/deployment/server
+          mountPath: /home/wso2carbon/wso2ei-6.4.0/wso2/business-process/repository/deployment/server
       imagePullSecrets:
       - name: wso2creds
       serviceAccountName: "wso2svc-account"

--- a/scalable-integrator/integrator-deployment.yaml
+++ b/scalable-integrator/integrator-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: wso2ei-scalable-integrator
-        image: docker.wso2.com/wso2ei-integrator:6.2.0
+        image: docker.wso2.com/wso2ei-integrator:6.4.0
         livenessProbe:
           exec:
             command:
@@ -66,7 +66,7 @@ spec:
         - name: integrator-conf-datasources
           mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf-datasources
         - name: shared-pd
-          mountPath: /home/wso2carbon/wso2ei-6.2.0/repository/deployment/server
+          mountPath: /home/wso2carbon/wso2ei-6.4.0/repository/deployment/server
       serviceAccountName: "wso2svc-account"
       imagePullSecrets:
       - name: wso2creds

--- a/scalable-mb/message-broker-deployment.yaml
+++ b/scalable-mb/message-broker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: wso2ei-scalable-mb
-        image: docker.wso2.com/wso2ei-broker:6.2.0
+        image: docker.wso2.com/wso2ei-broker:6.4.0
         livenessProbe:
           exec:
             command:
@@ -72,7 +72,7 @@ spec:
         - name: mb-conf-datasources
           mountPath: /home/wso2carbon/kubernetes-volumes/broker/conf/datasources
         - name: mb-server-share-volume
-          mountPath: /home/wso2carbon/wso2ei-6.2.0/wso2/broker/repository/deployment/server
+          mountPath: /home/wso2carbon/wso2ei-6.4.0/wso2/broker/repository/deployment/server
       serviceAccountName: "wso2svc-account"
       imagePullSecrets:
       - name: wso2creds


### PR DESCRIPTION
## Purpose
> The deployment yamls for 6.4.x consists of incorrect mount paths and images. This PR fixes this issue.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes