### PR TITLE
Create two analytics worker deployments/services to avoid unready pods.

### DIFF
--- a/advanced/helm/ei-pattern-1/confs/integrator/conf/carbon.xml
+++ b/advanced/helm/ei-pattern-1/confs/integrator/conf/carbon.xml
@@ -655,8 +655,8 @@
             enable publishing events to the servers in a round robin manner.
             e.g.; tcp://analytics-server-1:7612,tcp://analytics-server-2:7612
          -->
-    <ServerURL>tcp://{{ WORKER_SERVICE }}:7612</ServerURL>
-    <AuthServerURL>ssl://{{ WORKER_SERVICE }}:7712</AuthServerURL>
+    <ServerURL>tcp://{{ WORKER_SERVICE-1 }}:7612|tcp://{{ WORKER_SERVICE-2 }}:7612</ServerURL>
+    <AuthServerURL>ssl://{{ WORKER_SERVICE-1 }}:7712|ssl://{{ WORKER_SERVICE-2 }}:7712</AuthServerURL>
     <!--
             Credentails of the admin user of the analytics server.
         -->

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-1.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-1.yaml
@@ -1,0 +1,210 @@
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-analytics-worker-deployment-1
+  namespace : {{ .Release.Namespace }}
+spec:
+  replicas: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker1.replicas }}
+  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker1.minReadySeconds }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker1.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker1.strategy.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      deployment: {{ template "fullname" . }}-analytics-worker-1
+  template:
+    metadata:
+      labels:
+        deployment: {{ template "fullname" . }}-analytics-worker-1
+    spec:
+      initContainers:
+      {{ if .Values.wso2.mysql.enabled }}
+      - name: init-ei-db
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of MySQL Server deployment"; while ! nc -z {{ default "wso2ei-rdbms-service-mysql" .Values.wso2.mysql.host }} 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
+      {{ end }}
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+      - name: init-logstash-plugins-install
+        image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
+        command:
+          - /bin/sh
+          - "-c"
+          - |
+            set -e
+            ./bin/logstash-plugin install logstash-codec-multiline logstash-filter-grok
+        volumeMounts:
+          - name: shared-plugins
+            mountPath: /usr/share/logstash/plugins/
+      - name: init-elasticsearch
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
+      {{ end }}
+      containers:
+      - name: wso2ei-analytics-worker
+        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker1.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
+        {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
+        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
+        {{ else }}
+        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
+        {{ end }}
+        env:
+        -
+          name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          limits:
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.limits.cpu }}
+          requests:
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.requests.cpu }}
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker1.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker1.livenessProbe.periodSeconds }}
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker1.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker1.readinessProbe.periodSeconds }}
+        lifecycle:
+          preStop:
+            exec:
+              command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/analytics-worker.sh stop']
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 802
+        ports:
+          -
+            containerPort: 9444
+            protocol: TCP
+          -
+            containerPort: 9091
+            protocol: TCP
+          -
+            containerPort: 9711
+            protocol: TCP
+          -
+            containerPort: 9611
+            protocol: TCP
+          -
+            containerPort: 7712
+            protocol: TCP
+          -
+            containerPort: 7612
+            protocol: TCP
+          -
+            containerPort: 7070
+            protocol: TCP
+          -
+            containerPort: 7443
+            protocol: TCP
+          -
+            containerPort: 9894
+            protocol: TCP
+        volumeMounts:
+        - name: analytics-conf-worker
+          mountPath: /home/wso2carbon/wso2-config-volume/wso2/analytics/conf/worker
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+        - name: shared-logs
+          mountPath: /home/wso2carbon/wso2ei-6.5.0/wso2/analytics/wso2/worker/logs
+      - name: wso2ei-logstash
+        image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9600
+          initialDelaySeconds: {{ default 20 .Values.wso2.centralizedLogging.logstash.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 30 .Values.wso2.centralizedLogging.logstash.livenessProbe.periodSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9600
+          initialDelaySeconds: {{ default 20 .Values.wso2.centralizedLogging.logstash.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 30 .Values.wso2.centralizedLogging.logstash.readinessProbe.periodSeconds }}
+        volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/logstash/wso2-logs/
+          - name: logstash-yml
+            mountPath: /usr/share/logstash/config/logstash.yml
+            subPath: logstash.yml
+          - name: c4-logstash-conf
+            mountPath: /usr/share/logstash/pipeline/logstash.conf
+            subPath: logstash.conf
+          - name: shared-plugins
+            mountPath: /usr/share/logstash/plugins/
+        env:
+          - name: NODE_ID
+            value: {{ default "wso2ei-node" .Values.wso2.centralizedLogging.logstash.indexNodeID.wso2EINode }}
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: ELASTICSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: logstash-elasticsearch-creds
+                key: username
+          - name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: logstash-elasticsearch-creds
+                key: password
+          - name: ELASTICSEARCH_HOST
+            value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
+      {{ end }}
+      serviceAccountName: {{ .Values.kubernetes.svcaccount }}
+      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker1.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      imagePullSecrets:
+      - name: wso2ei-deployment-creds
+      {{ end }}
+      volumes:
+      - name: analytics-conf-worker
+        configMap:
+          name: analytics-conf-worker
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+      - name: shared-logs
+        emptyDir: {}
+      - name: logstash-yml
+        configMap:
+          name: logstash-yml
+      - name: c4-logstash-conf
+        configMap:
+          name: c4-logstash-conf
+      - name: shared-plugins
+        emptyDir: {}
+      - name: logstash-elasticsearch-creds
+        secret:
+          secretName: logstash-elasticsearch-creds
+      {{ end }}

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-2.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-2.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-2.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-deployment-2.yaml
@@ -1,0 +1,210 @@
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}-analytics-worker-deployment-2
+  namespace : {{ .Release.Namespace }}
+spec:
+  replicas: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker2.replicas }}
+  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker2.minReadySeconds }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker2.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker2.strategy.rollingUpdate.maxUnavailable }}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      deployment: {{ template "fullname" . }}-analytics-worker-2
+  template:
+    metadata:
+      labels:
+        deployment: {{ template "fullname" . }}-analytics-worker-2
+    spec:
+      initContainers:
+      {{ if .Values.wso2.mysql.enabled }}
+      - name: init-ei-db
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of MySQL Server deployment"; while ! nc -z {{ default "wso2ei-rdbms-service-mysql" .Values.wso2.mysql.host }} 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
+      {{ end }}
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+      - name: init-logstash-plugins-install
+        image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
+        command:
+          - /bin/sh
+          - "-c"
+          - |
+            set -e
+            ./bin/logstash-plugin install logstash-codec-multiline logstash-filter-grok
+        volumeMounts:
+          - name: shared-plugins
+            mountPath: /usr/share/logstash/plugins/
+      - name: init-elasticsearch
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
+      {{ end }}
+      containers:
+      - name: wso2ei-analytics-worker
+        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker2.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
+        {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
+        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
+        {{ else }}
+        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
+        {{ end }}
+        env:
+        -
+          name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          limits:
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.limits.cpu }}
+          requests:
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.requests.cpu }}
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker2.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker2.livenessProbe.periodSeconds }}
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker2.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker2.readinessProbe.periodSeconds }}
+        lifecycle:
+          preStop:
+            exec:
+              command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/analytics-worker.sh stop']
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 802
+        ports:
+          -
+            containerPort: 9444
+            protocol: TCP
+          -
+            containerPort: 9091
+            protocol: TCP
+          -
+            containerPort: 9711
+            protocol: TCP
+          -
+            containerPort: 9611
+            protocol: TCP
+          -
+            containerPort: 7712
+            protocol: TCP
+          -
+            containerPort: 7612
+            protocol: TCP
+          -
+            containerPort: 7070
+            protocol: TCP
+          -
+            containerPort: 7443
+            protocol: TCP
+          -
+            containerPort: 9894
+            protocol: TCP
+        volumeMounts:
+        - name: analytics-conf-worker
+          mountPath: /home/wso2carbon/wso2-config-volume/wso2/analytics/conf/worker
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+        - name: shared-logs
+          mountPath: /home/wso2carbon/wso2ei-6.5.0/wso2/analytics/wso2/worker/logs
+      - name: wso2ei-logstash
+        image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 9600
+          initialDelaySeconds: {{ default 20 .Values.wso2.centralizedLogging.logstash.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 30 .Values.wso2.centralizedLogging.logstash.livenessProbe.periodSeconds }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 9600
+          initialDelaySeconds: {{ default 20 .Values.wso2.centralizedLogging.logstash.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 30 .Values.wso2.centralizedLogging.logstash.readinessProbe.periodSeconds }}
+        volumeMounts:
+          - name: shared-logs
+            mountPath: /usr/share/logstash/wso2-logs/
+          - name: logstash-yml
+            mountPath: /usr/share/logstash/config/logstash.yml
+            subPath: logstash.yml
+          - name: c4-logstash-conf
+            mountPath: /usr/share/logstash/pipeline/logstash.conf
+            subPath: logstash.conf
+          - name: shared-plugins
+            mountPath: /usr/share/logstash/plugins/
+        env:
+          - name: NODE_ID
+            value: {{ default "wso2ei-node" .Values.wso2.centralizedLogging.logstash.indexNodeID.wso2EINode }}
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: ELASTICSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: logstash-elasticsearch-creds
+                key: username
+          - name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: logstash-elasticsearch-creds
+                key: password
+          - name: ELASTICSEARCH_HOST
+            value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
+      {{ end }}
+      serviceAccountName: {{ .Values.kubernetes.svcaccount }}
+      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker2.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      imagePullSecrets:
+      - name: wso2ei-deployment-creds
+      {{ end }}
+      volumes:
+      - name: analytics-conf-worker
+        configMap:
+          name: analytics-conf-worker
+      {{ if .Values.wso2.centralizedLogging.enabled }}
+      - name: shared-logs
+        emptyDir: {}
+      - name: logstash-yml
+        configMap:
+          name: logstash-yml
+      - name: c4-logstash-conf
+        configMap:
+          name: c4-logstash-conf
+      - name: shared-plugins
+        emptyDir: {}
+      - name: logstash-elasticsearch-creds
+        secret:
+          secretName: logstash-elasticsearch-creds
+      {{ end }}

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-service-1.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-service-1.yaml
@@ -15,11 +15,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-service
+  name: {{ template "fullname" . }}-analytics-worker-service-1
   namespace : {{ .Release.Namespace }}
 spec:
   selector:
-    deployment: {{ template "fullname" . }}-analytics-worker
+    deployment: {{ template "fullname" . }}-analytics-worker-1
   ports:
   - name: data-receiver-2
     port: 7612

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-service-2.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-service-2.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/advanced/helm/ei-pattern-1/templates/analytics-worker-service-2.yaml
+++ b/advanced/helm/ei-pattern-1/templates/analytics-worker-service-2.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-analytics-worker-service-2
+  namespace : {{ .Release.Namespace }}
+spec:
+  selector:
+    deployment: {{ template "fullname" . }}-analytics-worker-2
+  ports:
+  - name: data-receiver-2
+    port: 7612
+    targetPort: 7612
+    protocol: TCP
+  - name: http-default
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  - name: siddhi-defaul
+    port: 7070
+    targetPort: 8082
+    protocol: TCP
+  - name: siddhi-msf4j-https
+    port: 7443
+    targetPort: 11501
+    protocol: TCP
+  - name: data-receiver-1
+    port: 7712
+    targetPort: 7712
+    protocol: TCP
+  - name: http-msf4j-https
+    port: 9444
+    targetPort: 9444
+    protocol: TCP
+  - name: data-receiver-binary-1
+    port: 9711
+    targetPort: 9711
+    protocol: TCP
+  - name: data-receiver-binary-2
+    port: 9611
+    targetPort: 9611
+    protocol: TCP

--- a/advanced/helm/ei-pattern-1/templates/integrator-conf.yaml
+++ b/advanced/helm/ei-pattern-1/templates/integrator-conf.yaml
@@ -21,7 +21,8 @@ data:
   {{- $hostname := printf "%s%s" .Release.Name "-gateway" }}
   {{- $mgtHostname := printf "%s%s" .Release.Name "-integrator" }}
   {{- $fullname := include "fullname" . }}
-  {{- $workerService := printf "%s%s" $fullname "-analytics-worker-service" }}
+  {{- $workerService1 := printf "%s%s" $fullname "-analytics-worker-service-1" }}
+  {{- $workerService2 := printf "%s%s" $fullname "-analytics-worker-service-2" }}
   {{- $file := .Files }}
   {{- range $path, $byte := .Files.Glob "confs/integrator/conf/*" }}
   {{- $list := $path | splitList "/"}}
@@ -29,6 +30,6 @@ data:
   {{- $last := add $length -1 }}
   {{ index $list $last }}: |-
     {{- range $line := $file.Lines $path }}
-      {{ $line | replace "{{ HOSTNAME }}" $hostname | replace "{{ MGT_HOSTNAME }}" $mgtHostname | replace "{{ WORKER_SERVICE }}" $workerService }}
+      {{ $line | replace "{{ HOSTNAME }}" $hostname | replace "{{ MGT_HOSTNAME }}" $mgtHostname | replace "{{ WORKER_SERVICE-1 }}" $workerService1 | replace "{{ WORKER_SERVICE-2 }}" $workerService2  }}
     {{- end }}
   {{- end }}

--- a/advanced/helm/ei-pattern-1/templates/integrator-deployment.yaml
+++ b/advanced/helm/ei-pattern-1/templates/integrator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{ end }}
         - name: init-ei-analytics
           image: busybox:1.31
-          command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics profile of WSO2 Enterprise Integrator deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> Analytics profile of WSO2 Enterprise Integrator has started";']
+          command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics profile of WSO2 Enterprise Integrator deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-service-1 7712; do sleep 1; printf "-"; done; echo -e "  >> Analytics profile of WSO2 Enterprise Integrator has started";']
         {{ if .Values.wso2.centralizedLogging.enabled }}
         - name: init-logstash-plugins-install
           image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}

--- a/advanced/helm/ei-pattern-1/values.yaml
+++ b/advanced/helm/ei-pattern-1/values.yaml
@@ -48,10 +48,38 @@ wso2:
           memory: "2Gi"
           cpu: "2000m"
       imagePullPolicy: Always
-    wso2eiAnalyticsWorker:
+    wso2eiAnalyticsWorker1:
       imageName: "wso2ei-analytics-worker"
       imageTag: "6.5.0"
-      replicas: 2
+      replicas: 1
+      minReadySeconds: 75
+      strategy:
+        rollingUpdate:
+          maxSurge: 2
+          maxUnavailable: 0
+      livenessProbe:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+      readinessProbe:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+      resources:
+        # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
+        # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
+        requests:
+          memory: "4Gi"
+          cpu: "2000m"
+        # Please see the official documentation on WSO2 Stream Processor based Performance Analysis and Resource recommendations
+        # (https://docs.wso2.com/display/SP440/Performance+Analysis+Results) and tune the limits according to your needs
+        # where necessary.
+        limits:
+          memory: "4Gi"
+          cpu: "2000m"
+      imagePullPolicy: Always
+    wso2eiAnalyticsWorker2:
+      imageName: "wso2ei-analytics-worker"
+      imageTag: "6.5.0"
+      replicas: 1
       minReadySeconds: 75
       strategy:
         rollingUpdate:

--- a/advanced/helm/ei-pattern-2/confs/integrator/conf/carbon.xml
+++ b/advanced/helm/ei-pattern-2/confs/integrator/conf/carbon.xml
@@ -655,8 +655,8 @@
             enable publishing events to the servers in a round robin manner.
             e.g.; tcp://analytics-server-1:7612,tcp://analytics-server-2:7612
          -->
-    <ServerURL>tcp://{{ WORKER_SERVICE }}:7612</ServerURL>
-    <AuthServerURL>ssl://{{ WORKER_SERVICE }}:7712</AuthServerURL>
+    <ServerURL>tcp://{{ WORKER_SERVICE-1 }}:7612|tcp://{{ WORKER_SERVICE-2 }}:7612</ServerURL>
+    <AuthServerURL> ssl://{{ WORKER_SERVICE-1 }}:7712|ssl://{{ WORKER_SERVICE-2 }}:7712</AuthServerURL>
     <!--
             Credentails of the admin user of the analytics server.
         -->

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-1.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-1.yaml
@@ -15,23 +15,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-deployment
+  name: {{ template "fullname" . }}-analytics-worker-deployment-1
   namespace : {{ .Release.Namespace }}
 spec:
-  replicas: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker.replicas }}
-  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker.minReadySeconds }}
+  replicas: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker1.replicas }}
+  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker1.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker1.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker1.strategy.rollingUpdate.maxUnavailable }}
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: {{ template "fullname" . }}-analytics-worker
+      deployment: {{ template "fullname" . }}-analytics-worker-1
   template:
     metadata:
       labels:
-        deployment: {{ template "fullname" . }}-analytics-worker
+        deployment: {{ template "fullname" . }}-analytics-worker-1
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -43,7 +43,7 @@ spec:
       - name: init-logstash-plugins-install
         image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
         command:
-          - /bin/sh
+          - /bin/bash
           - "-c"
           - |
             set -e
@@ -56,15 +56,15 @@ spec:
         command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
       {{ end }}
       containers:
-      - name: wso2ei-analytics-worker
-        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker.dockerRegistry }}
-        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}
-        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+      - name: integrator-with-analytics-ei-analytics
+        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker1.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
         {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
-        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
         {{ else }}
-        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imageTag }}
         {{ end }}
         env:
         -
@@ -73,28 +73,28 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         resources:
-          limits:
-            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.limits.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.limits.cpu }}
           requests:
-            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.requests.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.requests.cpu }}
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.resources.limits.cpu }}
         livenessProbe:
           exec:
             command:
-            - /bin/sh
-            - -c
-            - nc -z localhost 9444
-          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker.livenessProbe.periodSeconds }}
+              - /bin/sh
+              - -c
+              - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker1.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker1.livenessProbe.periodSeconds }}
         readinessProbe:
           exec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 7712
-          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker.readinessProbe.periodSeconds }}
+              - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker1.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker1.readinessProbe.periodSeconds }}
         lifecycle:
           preStop:
             exec:
@@ -103,39 +103,39 @@ spec:
         securityContext:
           runAsUser: 802
         ports:
-          -
-            containerPort: 9444
-            protocol: TCP
-          -
-            containerPort: 9091
-            protocol: TCP
-          -
-            containerPort: 9711
-            protocol: TCP
-          -
-            containerPort: 9611
-            protocol: TCP
-          -
-            containerPort: 7712
-            protocol: TCP
-          -
-            containerPort: 7612
-            protocol: TCP
-          -
-            containerPort: 7070
-            protocol: TCP
-          -
-            containerPort: 7443
-            protocol: TCP
-          -
-            containerPort: 9894
-            protocol: TCP
+        -
+          containerPort: 9444
+          protocol: TCP
+        -
+          containerPort: 9091
+          protocol: TCP
+        -
+          containerPort: 9712
+          protocol: TCP
+        -
+          containerPort: 9612
+          protocol: TCP
+        -
+          containerPort: 7712
+          protocol: TCP
+        -
+          containerPort: 7612
+          protocol: TCP
+        -
+          containerPort: 7070
+          protocol: TCP
+        -
+          containerPort: 7443
+          protocol: TCP
+        -
+          containerPort: 9894
+          protocol: TCP
         volumeMounts:
-        - name: analytics-conf-worker
-          mountPath: /home/wso2carbon/wso2-config-volume/wso2/analytics/conf/worker
+          - name: analytics-conf-worker
+            mountPath: /home/wso2carbon/wso2-config-volume/wso2/analytics/conf/worker
       {{ if .Values.wso2.centralizedLogging.enabled }}
-        - name: shared-logs
-          mountPath: /home/wso2carbon/wso2ei-6.5.0/wso2/analytics/wso2/worker/logs
+          - name: shared-logs
+            mountPath: /home/wso2carbon/wso2ei-6.5.0/wso2/analytics/wso2/worker/logs
       - name: wso2ei-logstash
         image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
         livenessProbe:
@@ -180,31 +180,31 @@ spec:
                 key: password
           - name: ELASTICSEARCH_HOST
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
-      {{ end }}
+      {{- end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker.imagePullSecrets }}
+      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker1.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imagePullSecrets }}
+      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker1.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-      - name: wso2ei-deployment-creds
-      {{ end }}
+        - name: wso2ei-deployment-creds
+      {{- end }}
       volumes:
-      - name: analytics-conf-worker
-        configMap:
-          name: analytics-conf-worker
-      {{ if .Values.wso2.centralizedLogging.enabled }}
-      - name: shared-logs
-        emptyDir: {}
-      - name: logstash-yml
-        configMap:
-          name: logstash-yml
-      - name: c4-logstash-conf
-        configMap:
-          name: c4-logstash-conf
-      - name: shared-plugins
-        emptyDir: {}
-      - name: logstash-elasticsearch-creds
-        secret:
-          secretName: logstash-elasticsearch-creds
-      {{ end }}
+        - name: analytics-conf-worker
+          configMap:
+            name: analytics-conf-worker
+        {{- if .Values.wso2.centralizedLogging.enabled }}
+        - name: shared-logs
+          emptyDir: {}
+        - name: logstash-yml
+          configMap:
+            name: logstash-yml
+        - name: c4-logstash-conf
+          configMap:
+            name: c4-logstash-conf
+        - name: shared-plugins
+          emptyDir: {}
+        - name: logstash-elasticsearch-creds
+          secret:
+            secretName: logstash-elasticsearch-creds
+        {{- end }}

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-2.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-2.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-2.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-deployment-2.yaml
@@ -15,23 +15,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-deployment
+  name: {{ template "fullname" . }}-analytics-worker-deployment-2
   namespace : {{ .Release.Namespace }}
 spec:
-  replicas: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker.replicas }}
-  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker.minReadySeconds }}
+  replicas: {{ default 1 .Values.wso2.deployment.wso2eiAnalyticsWorker2.replicas }}
+  minReadySeconds: {{ default 75 .Values.wso2.deployment.wso2eiAnalyticsWorker2.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ default 2 .Values.wso2.deployment.wso2eiAnalyticsWorker2.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2eiAnalyticsWorker2.strategy.rollingUpdate.maxUnavailable }}
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: {{ template "fullname" . }}-analytics-worker
+      deployment: {{ template "fullname" . }}-analytics-worker-2
   template:
     metadata:
       labels:
-        deployment: {{ template "fullname" . }}-analytics-worker
+        deployment: {{ template "fullname" . }}-analytics-worker-2
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -57,14 +57,14 @@ spec:
       {{ end }}
       containers:
       - name: integrator-with-analytics-ei-analytics
-        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker.dockerRegistry }}
-        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}
-        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+        {{ if .Values.wso2.deployment.wso2eiAnalyticsWorker2.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.dockerRegistry }}/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
         {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
-        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+        image: wso2/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
         {{ else }}
-        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imageTag }}
+        image: docker.wso2.com/{{ default "wso2ei-analytics-worker" .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageName }}:{{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imageTag }}
         {{ end }}
         env:
         -
@@ -74,27 +74,27 @@ spec:
               fieldPath: status.podIP
         resources:
           requests:
-            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.requests.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.requests.cpu }}
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.requests.cpu }}
           limits:
-            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.limits.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.resources.limits.cpu }}
+            memory: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.resources.limits.cpu }}
         livenessProbe:
           exec:
             command:
               - /bin/sh
               - -c
               - nc -z localhost 9444
-          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker.livenessProbe.periodSeconds }}
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker2.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker2.livenessProbe.periodSeconds }}
         readinessProbe:
           exec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 7712
-          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker.readinessProbe.periodSeconds }}
+              - nc -z localhost 9444
+          initialDelaySeconds: {{ default 20 .Values.wso2.deployment.wso2eiAnalyticsWorker2.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2eiAnalyticsWorker2.readinessProbe.periodSeconds }}
         lifecycle:
           preStop:
             exec:
@@ -182,9 +182,9 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{- end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker.imagePullSecrets }}
+      {{- if .Values.wso2.deployment.wso2eiAnalyticsWorker2.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker.imagePullSecrets }}
+      - name: {{ .Values.wso2.deployment.wso2eiAnalyticsWorker2.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
         - name: wso2ei-deployment-creds

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-service-1.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-service-1.yaml
@@ -15,11 +15,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-service
+  name: {{ template "fullname" . }}-analytics-worker-service-1
   namespace : {{ .Release.Namespace }}
 spec:
   selector:
-    deployment: {{ template "fullname" . }}-analytics-worker
+    deployment: {{ template "fullname" . }}-analytics-worker-1
   ports:
   - name: data-receiver-2
     port: 7612

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-service-2.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-service-2.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/advanced/helm/ei-pattern-2/templates/analytics-worker-service-2.yaml
+++ b/advanced/helm/ei-pattern-2/templates/analytics-worker-service-2.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}-analytics-worker-service-2
+  namespace : {{ .Release.Namespace }}
+spec:
+  selector:
+    deployment: {{ template "fullname" . }}-analytics-worker-2
+  ports:
+  - name: data-receiver-2
+    port: 7612
+    targetPort: 7612
+    protocol: TCP
+  - name: http-default
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  - name: siddhi-defaul
+    port: 7070
+    targetPort: 8082
+    protocol: TCP
+  - name: siddhi-msf4j-https
+    port: 7443
+    targetPort: 11501
+    protocol: TCP
+  - name: data-receiver-1
+    port: 7712
+    targetPort: 7712
+    protocol: TCP
+  - name: http-msf4j-https
+    port: 9444
+    targetPort: 9444
+    protocol: TCP
+  - name: data-receiver-binary-1
+    port: 9711
+    targetPort: 9711
+    protocol: TCP
+  - name: data-receiver-binary-2
+    port: 9611
+    targetPort: 9611
+    protocol: TCP

--- a/advanced/helm/ei-pattern-2/templates/integrator-conf.yaml
+++ b/advanced/helm/ei-pattern-2/templates/integrator-conf.yaml
@@ -22,7 +22,8 @@ data:
   {{- $mgtHostname := printf "%s%s" .Release.Name "-integrator" }}
   {{- $fullname := include "fullname" . }}
   {{- $brokerService := printf "%s%s" $fullname "-mb-service" }}
-  {{- $workerService := printf "%s%s" $fullname "-analytics-worker-service" }}
+  {{- $workerService1 := printf "%s%s" $fullname "-analytics-worker-service-1" }}
+  {{- $workerService2 := printf "%s%s" $fullname "-analytics-worker-service-2" }}
   {{- $file := .Files }}
   {{- range $path, $byte := .Files.Glob "confs/integrator/conf/*" }}
   {{- $list := $path | splitList "/"}}
@@ -30,6 +31,6 @@ data:
   {{- $last := add $length -1 }}
   {{ index $list $last }}: |-
     {{- range $line := $file.Lines $path }}
-      {{ $line | replace "{{ HOSTNAME }}" $hostname | replace "{{ MGT_HOSTNAME }}" $mgtHostname | replace "{{ BROKER_SERVICE }}" $brokerService | replace "{{ WORKER_SERVICE }}" $workerService }}
+      {{ $line | replace "{{ HOSTNAME }}" $hostname | replace "{{ MGT_HOSTNAME }}" $mgtHostname | replace "{{ BROKER_SERVICE }}" $brokerService | replace "{{ WORKER_SERVICE-1 }}" $workerService1 | replace "{{ WORKER_SERVICE-2 }}" $workerService2  }}
     {{- end }}
   {{- end }}

--- a/advanced/helm/ei-pattern-2/templates/integrator-deployment.yaml
+++ b/advanced/helm/ei-pattern-2/templates/integrator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{ end }}
         - name: init-ei-analytics
           image: busybox:1.31
-          command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics profile of WSO2 Enterprise Integrator deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> Analytics profile of WSO2 Enterprise Integrator has started";']
+          command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics profile of WSO2 Enterprise Integrator deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-service-1 7712; do sleep 1; printf "-"; done; echo -e "  >> Analytics profile of WSO2 Enterprise Integrator has started";']
         - name: init-ei-broker
           image: busybox:1.31
           command: ['sh', '-c', 'echo -e "Checking for the availability of Broker profile of WSO2 Enterprise Integrator deployment"; while ! nc -z {{ template "fullname" . }}-mb-service 5675; do sleep 1; printf "-"; done; echo -e "  >> Broker profile of WSO2 Enterprise Integrator has started";']

--- a/advanced/helm/ei-pattern-2/values.yaml
+++ b/advanced/helm/ei-pattern-2/values.yaml
@@ -74,14 +74,42 @@ wso2:
         limits:
           memory: "2Gi"
           cpu: "2000m"
-    wso2eiAnalyticsWorker:
+    wso2eiAnalyticsWorker1:
       imageName: "wso2ei-analytics-worker"
       imageTag: "6.5.0"
-      replicas: 2
+      replicas: 1
       minReadySeconds: 30
       strategy:
         rollingUpdate:
-          maxSurge: 2
+          maxSurge: 1
+          maxUnavailable: 0
+      livenessProbe:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+      readinessProbe:
+        initialDelaySeconds: 20
+        periodSeconds: 10
+      imagePullPolicy: Always
+      resources:
+        # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
+        # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
+        requests:
+          memory: "4Gi"
+          cpu: "2000m"
+        # Please see the official documentation on WSO2 Stream Processor based Performance Analysis and Resource recommendations
+        # (https://docs.wso2.com/display/SP440/Performance+Analysis+Results) and tune the limits according to your needs
+        # where necessary.
+        limits:
+          memory: "4Gi"
+          cpu: "2000m"
+    wso2eiAnalyticsWorker2:
+      imageName: "wso2ei-analytics-worker"
+      imageTag: "6.5.0"
+      replicas: 1
+      minReadySeconds: 30
+      strategy:
+        rollingUpdate:
+          maxSurge: 1
           maxUnavailable: 0
       livenessProbe:
         initialDelaySeconds: 20


### PR DESCRIPTION
## Purpose
Currently analytics worker is in HA where on pod is passive and since the readiness probe is to the analytics port, the said pod is never ready. This is problematic when it comes to deployment tools such as spinnaker which waits for the pods to be ready after a deployment.

To avoid this, we will use two deployments of analytics worker fronted by a service each. The pods will be ready for each service since the readiness probe is set to the 9443 port. But only one service will serve traffic since we are using `Failover configuration`[1] of services in the integrator.

[1] https://docs.wso2.com/display/EI650/Load+Balancing+the+ESB+Data+Published+to+Analytics