### PR TITLE
Fix incorrect secret name and ignore spinnaker versioning using annotation

### DIFF
--- a/advanced/helm/ei-pattern-1/templates/secrets.yaml
+++ b/advanced/helm/ei-pattern-1/templates/secrets.yaml
@@ -22,7 +22,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: wso2ei-integrator-deployment-creds
+  name: wso2ei-deployment-creds
   namespace : {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 data:

--- a/advanced/helm/ei-pattern-1/templates/secrets.yaml
+++ b/advanced/helm/ei-pattern-1/templates/secrets.yaml
@@ -24,6 +24,8 @@ kind: Secret
 metadata:
   name: wso2ei-deployment-creds
   namespace : {{ .Release.Namespace }}
+  annotations: 
+    "strategy.spinnaker.io/versioned" : "false"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $files.Get "auth.json" | replace "reg.id" $regId | replace "reg.username" $username | replace "reg.password" $password | replace "reg.email" $email | replace "reg.auth" $auth | b64enc }}

--- a/advanced/helm/ei-pattern-2/templates/secrets.yaml
+++ b/advanced/helm/ei-pattern-2/templates/secrets.yaml
@@ -24,6 +24,8 @@ kind: Secret
 metadata:
   name: wso2ei-deployment-creds
   namespace : {{ .Release.Namespace }}
+  annotations: 
+    "strategy.spinnaker.io/versioned" : "false"
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $files.Get "auth.json" | replace "reg.id" $regId | replace "reg.username" $username | replace "reg.password" $password | replace "reg.email" $email | replace "reg.auth" $auth | b64enc }}


### PR DESCRIPTION
## Purpose
- Fix incorrect secret name
- Spinnaker does not correctly version the imagePullSecret. Workaround for now is to disable secret versioning using the annotation `"strategy.spinnaker.io/versioned" : "false"`