### PR TITLE
Fixed "Kubernetes-volume" folder name

### DIFF
--- a/scalable-integrator/integrator-deployment.yaml
+++ b/scalable-integrator/integrator-deployment.yaml
@@ -62,9 +62,9 @@ spec:
         - name: integrator-conf
           mountPath: /home/wso2carbon/wso2-config-volume/conf
         - name: integrator-conf-axis2
-          mountPath: /home/wso2carbon/wso2-config-volume/conf-axis2
+          mountPath: /home/wso2carbon/wso2-config-volume/conf/axis2
         - name: integrator-conf-datasources
-          mountPath: /home/wso2carbon/wso2-config-volume/conf-datasources
+          mountPath: /home/wso2carbon/wso2-config-volume/conf/datasources
         - name: shared-pd
           mountPath: /home/wso2carbon/wso2ei-6.4.0/repository/deployment/server
       serviceAccountName: "wso2svc-account"

--- a/scalable-integrator/integrator-deployment.yaml
+++ b/scalable-integrator/integrator-deployment.yaml
@@ -60,11 +60,11 @@ spec:
           protocol: TCP
         volumeMounts:
         - name: integrator-conf
-          mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf
+          mountPath: /home/wso2carbon/wso2-config-volume/conf
         - name: integrator-conf-axis2
-          mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf-axis2
+          mountPath: /home/wso2carbon/wso2-config-volume/conf-axis2
         - name: integrator-conf-datasources
-          mountPath: /home/wso2carbon/kubernetes-volumes/integrator/conf-datasources
+          mountPath: /home/wso2carbon/wso2-config-volume/conf-datasources
         - name: shared-pd
           mountPath: /home/wso2carbon/wso2ei-6.4.0/repository/deployment/server
       serviceAccountName: "wso2svc-account"


### PR DESCRIPTION
The Deployment was different, from the other of the release, the deployment was unable to load configMaps beacause in wrong path.
Allineated with other Deployments


